### PR TITLE
Add mapping note: rps.document → EDW.DOCUMENT_RPS

### DIFF
--- a/docs/table-mappings.md
+++ b/docs/table-mappings.md
@@ -1,0 +1,17 @@
+# Table Mapping Notes
+
+## RPS Document Table
+
+The previous `rps.document` source should now be treated as `EDW.DOCUMENT_RPS`.
+
+When building queries, migrations, or data model references, use:
+
+- **Old name:** `rps.document`
+- **New name:** `EDW.DOCUMENT_RPS`
+
+Primary structural expectations from the provided DDL:
+
+- Engine: `SharedReplacingMergeTree(..., UPDATE_DL_TS)`
+- Partition key: `SERVER_NAM`
+- Primary key / order key: `SID`
+- Version column: `UPDATE_DL_TS`


### PR DESCRIPTION
### Motivation

- Clarify that the legacy `rps.document` source is now `EDW.DOCUMENT_RPS` and preserve the expected table semantics for downstream queries and data models.

### Description

- Add `docs/table-mappings.md` documenting the rename from `rps.document` to `EDW.DOCUMENT_RPS` and recording the DDL expectations (`SharedReplacingMergeTree`, partition key `SERVER_NAM`, primary/order key `SID`, and version column `UPDATE_DL_TS`).

### Testing

- Verified repository state and presence of the new mapping document via local repository checks; the automated verification steps completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d546aa857c83229c6fbbfe7506a4a3)