### PR TITLE
Add ClickHouse DDL for rps.exchange_rate

### DIFF
--- a/sql/rps.exchange_rate.sql
+++ b/sql/rps.exchange_rate.sql
@@ -1,0 +1,34 @@
+CREATE TABLE EDW.EXCHANGE_RATE_RPS (
+    `SERVER_NAM` String,
+    `SID` Decimal(19, 0),
+    `CREATED_BY` String,
+    `MODIFIED_BY` String,
+    `CONTROLLER_SID` Decimal(19, 0),
+    `ORIGIN_APPLICATION` String,
+    `ROW_VERSION` Decimal(10, 0),
+    `TENANT_SID` Decimal(19, 0),
+    `CURRENCY_SID` Decimal(19, 0),
+    `BASE_CURRENCY_SID` Decimal(19, 0),
+    `TAKE_RATE` Decimal(20, 8),
+    `GIVE_RATE` Decimal(20, 8),
+    `COST_RATE` Decimal(20, 8),
+    `OFFICIAL_RATE` Decimal(20, 8),
+    `CREATED_DATETIME` String,
+    `MODIFIED_DATETIME` String,
+    `POST_DATE` String,
+    `EFFECTIVE_DATE` String,
+    `DL_TS` String,
+    `UPDATE_DL_TS` String,
+    `month` Int64,
+    `year` Int64,
+    `_path` LowCardinality(String),
+    `_file` LowCardinality(String),
+    `_size` Nullable(UInt64),
+    `_time` Nullable(DateTime),
+    `toUnixTimestamp(DL_TS)` UInt64
+)
+ENGINE = SharedReplacingMergeTree('/clickhouse/tables/{uuid}/{shard}', '{replica}', `toUnixTimestamp(DL_TS)`)
+PARTITION BY SERVER_NAM
+PRIMARY KEY SID
+ORDER BY SID
+SETTINGS index_granularity = 8192;


### PR DESCRIPTION
### Motivation
- Add a ClickHouse DDL script to define the `EDW.EXCHANGE_RATE_RPS` table for `rps.exchange_rate` using the provided column list and storage settings.

### Description
- Create `sql/rps.exchange_rate.sql` containing the `CREATE TABLE EDW.EXCHANGE_RATE_RPS` statement with all specified columns, `SharedReplacingMergeTree` engine using `toUnixTimestamp(DL_TS)` as the version expression, `PARTITION BY SERVER_NAM`, `PRIMARY KEY SID` / `ORDER BY SID`, and `SETTINGS index_granularity = 8192`.

### Testing
- Ran `nl -ba sql/rps.exchange_rate.sql` to inspect the generated DDL file and confirm its contents, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d54b5188548322a3182e95e1a84b3b)