### PR TITLE
Add EDW.CURRENCY_RPS DDL for rps.currency

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,7 @@
 
 A small POC for querying the swapi api 
 
+
+## SQL table definitions
+
+- `sql/edw.currency_rps.sql`: ClickHouse `EDW.CURRENCY_RPS` DDL (source: user-provided definition for `rps.currency`).

--- a/sql/edw.currency_rps.sql
+++ b/sql/edw.currency_rps.sql
@@ -1,0 +1,40 @@
+CREATE TABLE EDW.CURRENCY_RPS (
+    `SERVER_NAM` String,
+    `SID` Decimal(19, 0),
+    `CREATED_BY` String,
+    `MODIFIED_BY` String,
+    `CONTROLLER_SID` Decimal(19, 0),
+    `ORIGIN_APPLICATION` String,
+    `ROW_VERSION` Decimal(10, 0),
+    `TENANT_SID` Decimal(19, 0),
+    `CURRENCY_NAME` String,
+    `DISCREPANCY` Decimal(16, 4),
+    `ROUNDING` Decimal(6, 2),
+    `DECIMALS` Decimal(3, 0),
+    `ACTIVE` Decimal(1, 0),
+    `ALPHABETIC_CODE` String,
+    `NUMERIC_CODE` Decimal(3, 0),
+    `MINOR_UNIT` Decimal(3, 0),
+    `SYMBOL` String,
+    `LTY_RATE` Decimal(16, 4),
+    `INTERNAL_FLAG` Decimal(1, 0),
+    `POST_DATE` String,
+    `MODIFIED_DATETIME` String,
+    `CREATED_DATETIME` String,
+    `UPDATE_DL_TS` String,
+    `DL_TS` String,
+    `_path` LowCardinality(String),
+    `_file` LowCardinality(String),
+    `_size` Nullable(UInt64),
+    `_time` Nullable(DateTime),
+    `LAST_TIME_UINT64 toUnixTimestamp(DL_TS)` UInt64
+)
+ENGINE = SharedReplacingMergeTree(
+    '/clickhouse/tables/{uuid}/{shard}',
+    '{replica}',
+    `LAST_TIME_UINT64 toUnixTimestamp(DL_TS)`
+)
+PARTITION BY SERVER_NAM
+PRIMARY KEY SID
+ORDER BY SID
+SETTINGS index_granularity = 8192;


### PR DESCRIPTION
### Motivation
- Capture the user-provided ClickHouse `EDW.CURRENCY_RPS` table definition for `rps.currency` in the repository so the DDL is versioned and discoverable.

### Description
- Add the DDL file at `sql/edw.currency_rps.sql` containing the provided `CREATE TABLE EDW.CURRENCY_RPS` statement and update `README.md` to document the new SQL definition location.

### Testing
- No automated tests were run for this DDL/documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d54ad490e08322b322c4f05691ef0c)